### PR TITLE
fix link for list comprehension resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ assignments in order to `print` out each individual assignment.
 
 [data-structures]: https://docs.python.org/3/tutorial/datastructures.html
 [for]: https://www.w3schools.com/python/python_for_loops.asp
-[list-comprehension]: https://www.w3schools.com/PYTHON/ref_list_pop.asp
+[list-comprehension]: https://www.w3schools.com/python/python_lists_comprehension.asp


### PR DESCRIPTION
the final link in resources was pointing to the w3schools page on .pop(), not list comprehensions, so I updated it